### PR TITLE
Use ES6 set in unique function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universe",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "The fastest way to query and explore multivariate datasets",
   "main": "src/universe.js",
   "directories": {

--- a/src/lodash.js
+++ b/src/lodash.js
@@ -221,9 +221,14 @@ function replaceArray(a, b) {
 }
 
 function uniq(a) {
-  var seen = {};
+  var seen = new Set();
   return a.filter(function(item) {
-    return seen.hasOwnProperty(item) ? false : (seen[item] = true);
+    var allow = false;
+    if (!seen.has(item)) {
+      seen.add(item);
+      allow = true;
+    }
+    return allow;
   });
 }
 


### PR DESCRIPTION
Uses the ES6 set inside the unique function. Will work on all modern browsers including IE11. Upped version to `0.3.7`

### Testing
Unit tests ran and passed.