### PR TITLE
Only package necessary files for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "directories": {
     "test": "test"
   },
+  "files": ["src","universe.*"],
   "dependencies": {
     "crossfilter2": "2.0.0-alpha.04",
     "q": "^1.4.1",


### PR DESCRIPTION
When publishing to npm the test files are not necessary.  With this change, the npm tarball is a little smaller.  Also ensures you do not accidentally add extra files.  You can check which files get packages for publication by running `npm pack`.