### PR TITLE
Fix bug preventing adding multiple aggregations to a query

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "space": 2,
     "rules": {
       "xo/filename-case": 0,
-      "comma-dangle": 0
+      "comma-dangle": 0,
+      "no-use-extend-native/no-use-extend-native": 1
     },
     "overrides": [
       {

--- a/src/reductiofy.js
+++ b/src/reductiofy.js
@@ -61,7 +61,7 @@ module.exports = function (service) {
         }
 
         // It's another nested object, so just repeat this process on it
-        reducer = aggregateOrNest(reducer.value(s.key), s.value)
+        aggregateOrNest(reducer.value(s.key), s.value)
       })
     }
   }

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -281,6 +281,32 @@ test('can query using the dataList aggregation', async t => {
 //   })
 // })
 
+test('supports multi aggregation', async t => {
+  const u = await universe(data)
+
+  const q = await u.query({
+    select: {
+      tip: {$sum: 'tip'},
+      total: {$sum: 'total'}
+    }
+  })
+
+  t.deepEqual(q.data, [
+    {key: 0, value: {tip: {sum: 100}, total: {sum: 190}}},
+    {key: 1, value: {tip: {sum: 100}, total: {sum: 190}}},
+    {key: 2, value: {tip: {sum: 200}, total: {sum: 300}}},
+    {key: 3, value: {tip: {sum: 0}, total: {sum: 90}}},
+    {key: 4, value: {tip: {sum: 0}, total: {sum: 90}}},
+    {key: 5, value: {tip: {sum: 0}, total: {sum: 90}}},
+    {key: 6, value: {tip: {sum: 0}, total: {sum: 100}}},
+    {key: 7, value: {tip: {sum: 0}, total: {sum: 90}}},
+    {key: 8, value: {tip: {sum: 0}, total: {sum: 90}}},
+    {key: 9, value: {tip: {sum: 0}, total: {sum: 90}}},
+    {key: 10, value: {tip: {sum: 0}, total: {sum: 200}}},
+    {key: 11, value: {tip: {sum: 100}, total: {sum: 200}}}
+  ])
+})
+
 test('can dispose of a query manually', async t => {
   const u = await universe(data)
 


### PR DESCRIPTION
The following piece of code only works if asked for *tip* or *total* but not both

```
select: {
  tip: { $sum: 'tip' },
  total: {  $sum: 'total', $avg: 'total' }
}
```

Full working example here: https://codepen.io/anon/pen/VWBoOB?editors=0011

When asking for more than one object in *query* => *reducer* becomes undefined in *aggregateOrNest()* when processing the second object